### PR TITLE
ICU for great Unicode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,20 @@
-ifdef DEBUG
-	EXTRA=-g
-else
-	EXTRA=
-endif
+PKGCONFIG_LIBS = icu-uc
 
-CFLAGS=-std=c99 ${EXTRA}
-OBJECTS=src/token.o src/ast.o src/ast_printer.o src/lexer.o src/segment.o
+CFLAGS = -std=c99
+ifdef DEBUG
+	CFLAGS += -g
+endif
+CFLAGS_PKGCONFIG = $(shell pkg-config --cflags ${PKGCONFIG_LIBS})
+CFLAGS += ${CFLAGS_PKGCONFIG}
+
+LDFLAGS_PKGCONFIG = $(shell pkg-config --libs ${PKGCONFIG_LIBS})
+LDFLAGS += ${LDFLAGS_PKGCONFIG}
+
+OBJECTS = src/token.o src/ast.o src/ast_printer.o src/lexer.o src/segment.o
 
 bin/segment: src/grammar.c ${OBJECTS}
 	mkdir -p bin/
-	gcc ${OBJECTS} -o bin/segment
+	${CC} ${LDFLAGS} ${OBJECTS} -o bin/segment
 
 src/lexer.c: src/lexer.rl src/grammar.c
 	ragel -C -G2 src/lexer.rl


### PR DESCRIPTION
Enforce UTF-8 encoding for all source files with [libicu4c](http://www.icu-project.org/apiref/icu4c/).
