### PR TITLE
Rename segment.{c|h} to other things.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CORE_OBJECTS = src/token.o src/ast.o src/parse_helpers.o src/lexer.o src/symbolt
 CORE_OBJECTS += src/ds/hashtable.o src/ds/murmur.o
 CORE_OBJECTS += src/debug/ast_printer.o src/debug/symbol_printer.o
 
-EXEC_OBJECTS = src/segment.o
+EXEC_OBJECTS = src/entry.o
 
 TEST_OBJECTS = tests/unit/suite.o
 TEST_OBJECTS += tests/unit/symboltable_tests.o

--- a/src/entry.c
+++ b/src/entry.c
@@ -9,7 +9,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 
-#include "segment.h"
+#include "options.h"
 #include "lexer.h"
 #include "debug/ast_printer.h"
 #include "debug/symbol_printer.h"

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -4,7 +4,7 @@
 #include <sys/types.h>
 
 #include "ast.h"
-#include "segment.h"
+#include "options.h"
 #include "symboltable.h"
 
 typedef struct {

--- a/src/lexer.rl
+++ b/src/lexer.rl
@@ -6,7 +6,7 @@
 #include "lexer.h"
 #include "ast.h"
 #include "token.h"
-#include "segment.h"
+#include "options.h"
 #include "parse_helpers.h"
 
 #include "grammar.h"

--- a/src/options.h
+++ b/src/options.h
@@ -1,5 +1,5 @@
-#ifndef SEGMENT_H
-#define SEGMENT_H
+#ifndef OPTIONS_H
+#define OPTIONS_H
 
 typedef struct {
   int lexer_debug;


### PR DESCRIPTION
I want to reserve `segment.h` as the entry point for compiling C extensions, so I'm renaming `segment.c` to `entry.c` and `segment.h` to `options.h`.
